### PR TITLE
docs: fix broken star history chart links

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 ## Star History
 
-[![Star History Chart](https://star-history.dera.page/svg?repos=starpig1129/DATAGEN&type=Date)](https://star-history.dera.page/#starpig1129/DATAGEN&type=Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=zi-yue-1129/DATAGEN&type=Date)](https://star-history.dera.page/#zi-yue-1129/DATAGEN&type=Date)
 
 ## Other Projects
 Here are some of my other notable projects:

--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=starpig1129/DATAGEN&type=Date)](https://star-history.com/#starpig1129/DATAGEN&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=starpig1129/DATAGEN&type=Date)](https://star-history.dera.page/#starpig1129/DATAGEN&type=Date)
 
 ## Other Projects
 Here are some of my other notable projects:

--- a/docs/zh-TW/README.md
+++ b/docs/zh-TW/README.md
@@ -241,7 +241,7 @@ DATAGEN 實現了強大的**漸進式揭露**架構用於代理配置，靈感�
 
 ## Star 歷史
 
-[![Star History Chart](https://api.star-history.com/svg?repos=starpig1129/DATAGEN&type=Date)](https://star-history.com/#starpig1129/DATAGEN&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=starpig1129/DATAGEN&type=Date)](https://star-history.dera.page/#starpig1129/DATAGEN&type=Date)
 
 ## 其他專案
 以下是我其他值得注意的專案：

--- a/docs/zh-TW/README.md
+++ b/docs/zh-TW/README.md
@@ -241,7 +241,7 @@ DATAGEN 實現了強大的**漸進式揭露**架構用於代理配置，靈感�
 
 ## Star 歷史
 
-[![Star History Chart](https://star-history.dera.page/svg?repos=starpig1129/DATAGEN&type=Date)](https://star-history.dera.page/#starpig1129/DATAGEN&type=Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=zi-yue-1129/DATAGEN&type=Date)](https://star-history.dera.page/#zi-yue-1129/DATAGEN&type=Date)
 
 ## 其他專案
 以下是我其他值得注意的專案：


### PR DESCRIPTION
The star history chart in README.md and docs/zh-TW/README.md is currently broken because of GitHub stargazer API restrictions. This change points the chart image and link to an alternative that works without an API token, so the chart displays correctly again. The update also moves the wrapping link to hash-based URLs matching the new chart format.