### PR TITLE
docs: refresh Other Projects section

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,10 +246,15 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 ## Other Projects
 Here are some of my other notable projects:
+
 ### PheroPath
 PheroPath is a filesystem-based stigmergy communication protocol that allows agents and humans to leave invisible "pheromones" (signals) on files. It enables communicating context, risks (DANGER), or status (TODO, SAFE) without modifying the file content itself, facilitating better multi-agent collaboration.
-- GitHub: [PheroPath](https://github.com/starpig1129/PheroPath)
-### PigPig: Advanced Multi-modal LLM Discord Bot: 
-A powerful Discord bot based on multi-modal Large Language Models (LLM), designed to interact with users through natural language. 
-It combines advanced AI capabilities with practical features, offering a rich experience for Discord communities.
-- GitHub: [ai-discord-bot-PigPig](https://github.com/starpig1129/ai-discord-bot-PigPig)
+- GitHub: [PheroPath](https://github.com/zi-yue-1129/PheroPath)
+
+### PigPig: Advanced Multi-modal LLM Discord Bot
+A powerful Discord bot based on multi-modal Large Language Models (LLM), designed to interact with users through natural language. It combines advanced AI capabilities with practical features, offering a rich experience for Discord communities.
+- GitHub: [ai-discord-bot-PigPig](https://github.com/zi-yue-1129/ai-discord-bot-PigPig)
+
+### research-lab-skills
+Composable Agent Skills covering the complete research lifecycle: literature review, research logs, experiment tracking, analysis, lab presentations, manuscript writing, and peer review.
+- GitHub: [research-lab-skills](https://github.com/zi-yue-1129/research-lab-skills)

--- a/docs/zh-TW/README.md
+++ b/docs/zh-TW/README.md
@@ -248,8 +248,12 @@ DATAGEN 實現了強大的**漸進式揭露**架構用於代理配置，靈感�
 
 ### PheroPath
 PheroPath 是一個基於檔案系統的共識主動性（Stigmergy）通訊協議，允許代理和人類在檔案上留下不可見的「費洛蒙」（信號）。它使得在不修改檔案內容的情況下溝通上下文、風險（DANGER）或狀態（TODO, SAFE）成為可能，從而促進更好的多代理協作。
-- GitHub: [PheroPath](https://github.com/starpig1129/PheroPath)
+- GitHub: [PheroPath](https://github.com/zi-yue-1129/PheroPath)
 
 ### PigPig：進階多模態 LLM Discord 機器人
 一個基於多模態大型語言模型（LLM）的強大 Discord 機器人，設計用於通過自然語言與用戶互動。它結合了先進的 AI 功能和實用功能，為 Discord 社群提供豐富的體驗。
-- GitHub: [ai-discord-bot-PigPig](https://github.com/starpig1129/ai-discord-bot-PigPig)
+- GitHub: [ai-discord-bot-PigPig](https://github.com/zi-yue-1129/ai-discord-bot-PigPig)
+
+### research-lab-skills
+涵蓋完整研究生命週期的可組合 Agent Skills：文獻回顧、研究日誌、實驗追蹤、分析、實驗室簡報、論文寫作與同儕審查。
+- GitHub: [research-lab-skills](https://github.com/zi-yue-1129/research-lab-skills)


### PR DESCRIPTION
## Summary
- Updates project links in the "Other Projects" section (README.md and docs/zh-TW/README.md) to the current GitHub owner name `zi-yue-1129`, instead of relying on the `starpig1129` redirect
- Adds `research-lab-skills` as a newly featured project

## Test plan
- [x] Verified all three project links return HTTP 200 (`zi-yue-1129/PheroPath`, `zi-yue-1129/ai-discord-bot-PigPig`, `zi-yue-1129/research-lab-skills`)